### PR TITLE
Fix how package is exposed

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -35,7 +35,8 @@
             "dev-develop": "3.1-dev"
         },
         "zf": {
-            "component": "Zend\\Router"
+            "component": "Zend\\Router",
+            "config-provider": "Zend\\Router\\ConfigProvider"
         }
     },
     "autoload-dev": {

--- a/composer.json
+++ b/composer.json
@@ -35,7 +35,7 @@
             "dev-develop": "3.1-dev"
         },
         "zf": {
-            "component": "Zend\\Mvc\\Router"
+            "component": "Zend\\Router"
         }
     },
     "autoload-dev": {


### PR DESCRIPTION
- Corrects the `component` name to `Zend\Router` (instead of `Zend\Mvc\Router`).
- Adds a `config-provider` mapping.