### PR TITLE
added @deprecated tag to Wildcard route

### DIFF
--- a/src/Http/Wildcard.php
+++ b/src/Http/Wildcard.php
@@ -14,6 +14,10 @@ use Zend\Stdlib\RequestInterface as Request;
 
 /**
  * Wildcard route.
+ *
+ * @deprecated since version 2.3.
+ * Misuse of this route type can lead to potential security issues.
+ * Use the `Segment` route type instead.
  */
 class Wildcard implements RouteInterface
 {


### PR DESCRIPTION
As per documentation the Wildcard route is deprecated.

This commit adds the `@deprecated` in the code.

Closes #6 since `Query` route was already removed
