### PR TITLE
remove Query traces in code, documentation and tests

### DIFF
--- a/doc/book/routing.md
+++ b/doc/book/routing.md
@@ -341,7 +341,6 @@ You may use any route type as a child route of a `Part` route.
 >     'scheme'   => 'Zend\Mvc\Router\Http\Scheme',
 >     'segment'  => 'Zend\Mvc\Router\Http\Segment',
 >     'wildcard' => 'Zend\Mvc\Router\Http\Wildcard',
->     'query'    => 'Zend\Mvc\Router\Http\Query',
 >     'method'   => 'Zend\Mvc\Router\Http\Method',
 > ];
 > foreach ($plugins as $name => $class) {
@@ -439,73 +438,6 @@ $route = Segment::factory([
     ],
 ]);
 ```
-
-### Zend\\Mvc\\Router\\Http\\Query (Deprecated)
-
-> #### Potential security issue
->
-> Misuse of this route can lead to potential security issues.
-
-> #### Deprecated
->
-> This route part is deprecated since you can now add query parameters without a
-> query route.
-
-The `Query` route part allows you to specify and capture query string parameters
-for a given route.
-
-The intention of the `Query` part is that you do not instantiate it in its own
-right, but use it as a child of another route part.
-
-An example of its usage would be:
-
-```php
-$route = Part::factory([
-    'route' => [
-        'type'    => 'literal',
-        'options' => [
-            'route'    => 'page',
-            'defaults' => [],
-        ],
-    ],
-    'may_terminate' => true,
-    'route_plugins' => $routePlugins,
-    'child_routes'  => [
-        'query' => [
-            'type' => 'Query',
-            'options' => [
-                'defaults' => [
-                    'foo' => 'bar',
-                ],
-            ],
-        ],
-    ],
-]);
-```
-
-This then allows you to create query strings using the url view helper.
-
-```php
-$this->url(
-    'page/query',
-    [
-        'name'   => 'my-test-page',
-        'format' => 'rss',
-        'limit'  => 10,
-    ]
-);
-```
-
-Per the above example, you must add `/query` (the name we gave to our query
-route segment) to your route name in order to append a query string. If you do
-not specify `/query` in the route name, then no query string will be appended.
-
-Our example "page" route has only one defined parameter of "name"
-(`/page[/:name]`), meaning that the remaining parameters of "format" and "limit"
-will then be appended as a query string.
-
-The output from our example should then be
-`/page/my-test-page?format=rss&limit=10`
 
 ### Zend\\Mvc\\Router\\Http\\Wildcard (Deprecated)
 

--- a/src/Http/Part.php
+++ b/src/Http/Part.php
@@ -156,10 +156,7 @@ class Part extends TreeRouteStack implements RouteInterface
             $pathLength = strlen($uri->getPath());
 
             if ($this->mayTerminate && $nextOffset === $pathLength) {
-                $query = $uri->getQuery();
-                if ('' == trim($query) || !$this->hasQueryChild()) {
-                    return $match;
-                }
+                return $match;
             }
 
             if (isset($options['translator'])
@@ -232,20 +229,5 @@ class Part extends TreeRouteStack implements RouteInterface
         // Part routes may not occur as base route of other part routes, so we
         // don't have to return anything here.
         return [];
-    }
-
-    /**
-     * Is one of the child routes a query route?
-     *
-     * @return bool
-     */
-    protected function hasQueryChild()
-    {
-        foreach ($this->routes as $route) {
-            if ($route instanceof Query) {
-                return true;
-            }
-        }
-        return false;
     }
 }

--- a/test/Http/PartTest.php
+++ b/test/Http/PartTest.php
@@ -149,15 +149,6 @@ class PartTest extends TestCase
                         'param_delimiter' => '/'
                     ]
                 ],
-                /*
-                'query' => array(
-                    'type' => 'Zend\Router\Http\Query',
-                    'options' => array(
-                        'key_value_delimiter' => '=',
-                        'param_delimiter' => '&'
-                    )
-                )
-                */
             ]
         );
     }
@@ -479,18 +470,6 @@ class PartTest extends TestCase
             ],
             'route_plugins' => self::getRoutePlugins(),
             'may_terminate' => true,
-            /*
-            'child_routes'  => array(
-                'query' => array(
-                    'type' => 'Zend\Router\Http\Query',
-                    'options' => array(
-                        'defaults' => array(
-                            'query' => 'string',
-                        ),
-                    ),
-                ),
-            ),
-            */
         ];
 
         $route = Part::factory($options);

--- a/test/Http/TreeRouteStackTest.php
+++ b/test/Http/TreeRouteStackTest.php
@@ -168,67 +168,6 @@ class TreeRouteStackTest extends TestCase
         $this->assertEquals('http://example.com/', $stack->assemble([], ['name' => 'foo']));
     }
 
-    public function testAssembleCanonicalUriWithHostnameRouteAndQueryRoute()
-    {
-        $this->markTestSkipped('Query route part has been deprecated in ZF as of 2.1.4');
-        $uri   = new HttpUri();
-        $uri->setScheme('http');
-        $stack = new TreeRouteStack();
-        $stack->setRequestUri($uri);
-        $stack->addRoute(
-            'foo',
-            [
-                'type' => 'Hostname',
-                'options' => [
-                    'route' => 'example.com',
-                ],
-                'child_routes' => [
-                    'index' => [
-                        'type' => 'Literal',
-                        'options' => [
-                            'route' => '/',
-                        ],
-                        'child_routes' => [
-                            'query' => [
-                                'type' => 'Query',
-                            ],
-                        ],
-                    ],
-                ],
-            ]
-        );
-
-        $this->assertEquals(
-            'http://example.com/?bar=baz',
-            $stack->assemble(['bar' => 'baz'], ['name' => 'foo/index/query'])
-        );
-    }
-
-    public function testAssembleWithQueryRoute()
-    {
-        $this->markTestSkipped('Query route part has been deprecated in ZF as of 2.1.4');
-        $uri   = new HttpUri();
-        $uri->setScheme('http');
-        $stack = new TreeRouteStack();
-        $stack->setRequestUri($uri);
-        $stack->addRoute(
-            'index',
-            [
-                'type' => 'Literal',
-                'options' => [
-                    'route' => '/',
-                ],
-                'child_routes' => [
-                    'query' => [
-                        'type' => 'Query',
-                    ],
-                ],
-            ]
-        );
-
-        $this->assertEquals('/?bar=baz', $stack->assemble(['bar' => 'baz'], ['name' => 'index/query']));
-    }
-
     public function testAssembleWithQueryParams()
     {
         $stack = new TreeRouteStack();


### PR DESCRIPTION
- removed the section about the removed Query route in the documentation
- removed the commented tests in `Http/PartTest`
- removed the skipped tests in `Http/TreeRouteStackTest`
- removed the now unuseful `hasQueryChild` method in `Http/Part`

I hope I'm not overdoing it. Just let me know if some of the things I removed needs to stay and I will adjust the PR
