### PR TITLE
Enhancement: Validate composer on Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -75,6 +75,7 @@ notifications:
 before_install:
   - travis_retry composer self-update
   - if [[ $TRAVIS_PHP_VERSION != "hhvm" && $TEST_COVERAGE != 'true' ]]; then phpenv config-rm xdebug.ini ; fi
+  - if [[ $DEPS == 'locked' ]]; then composer validate; fi
 
 install:
   - if [[ $DEPS == 'latest' ]]; then travis_retry composer update $COMPOSER_ARGS ; fi

--- a/composer.lock
+++ b/composer.lock
@@ -4,8 +4,8 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "hash": "8a56bb8928cc2f83c7275f110317b51a",
-    "content-hash": "dc9a1f1239947e2010e4d1f5b4578569",
+    "hash": "de8ff3f9afc436a25898066331c02c5c",
+    "content-hash": "b6fd779e6e020043d4050be3ef988d00",
     "packages": [
         {
             "name": "container-interop/container-interop",


### PR DESCRIPTION
This PR

* [x] validates `composer.json` and `composer.lock` on Travis
* [ ] updates `composer.lock` by running `composer update --lock`

💁 Running

```
$ composer validate
```

locally yields

```
./composer.json is valid
The lock file is not up to date with the latest changes in composer.json, it is recommended that you run `composer update`.
```