### PR TITLE
Fix: Typos in configuration example

### DIFF
--- a/doc/book/routing.md
+++ b/doc/book/routing.md
@@ -635,7 +635,7 @@ return [
                 'type' => 'Zend\Mvc\Router\Http\Hostname',
                 'options' => [
                     'route' => ':4th.[:3rd.]:2nd.:1st', // domain levels from right to left
-                    'contraints' => [
+                    'constraints' => [
                         '4th' => 'modules',
                         '3rd' => '.*?', // optional 3rd level domain such as .ci, .dev or .test
                         '2nd' => 'zendframework',
@@ -663,7 +663,7 @@ return [
                 'type' => 'Zend\Mvc\Router\Http\Hostname',
                 'options' => [
                     'route' => ':4th.[:3rd.]:2nd.:1st', // domain levels from right to left
-                    'contraints' => [
+                    'constraints' => [
                         '4th' => 'packages',
                         '3rd' => '.*?', // optional 3rd level domain such as .ci, .dev or .test
                         '2nd' => 'zendframework',


### PR DESCRIPTION
This PR

* [x] fixes typos in a route configuration example

💁 `contrains` should be `constraints`, shouldn't it?