### PR TITLE
Fix: Properly assign key a value

### DIFF
--- a/doc/book/routing.md
+++ b/doc/book/routing.md
@@ -652,7 +652,7 @@ return [
                             'route' => '/',
                             'defaults' => [
                                 'controller' => 'Module\Controller\Index',
-                                'action' = > 'index',
+                                'action' => 'index',
                             ],
                         ],
                         'may_terminate' => true,
@@ -680,7 +680,7 @@ return [
                             'route' => '/',
                             'defaults' => [
                                 'controller' => 'Package\Controller\Index',
-                                'action' = > 'index',
+                                'action' => 'index',
                             ],
                         ],
                         'may_terminate' => true,


### PR DESCRIPTION
This PR

* [x] properly assigns array keys a value in configuration examples