### PR TITLE
zend-mvc is not a conflict

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -29,9 +29,6 @@
     "suggest": {
         "zendframework/zend-i18n": "^2.6, if defining translatable HTTP path segments"
     },
-    "conflict": {
-        "zendframework/zend-mvc": "<3.0.0"
-    },
     "extra": {
         "branch-alias": {
             "dev-master": "3.0-dev",

--- a/composer.lock
+++ b/composer.lock
@@ -4,8 +4,8 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "hash": "de8ff3f9afc436a25898066331c02c5c",
-    "content-hash": "b6fd779e6e020043d4050be3ef988d00",
+    "hash": "2e2244e5bf4187038a46ffd867ad4f22",
+    "content-hash": "bc976e8fa694f92ccf1b545470d57f2b",
     "packages": [
         {
             "name": "container-interop/container-interop",


### PR DESCRIPTION
Despite #5, the classes in this package do not conflict with those in zend-mvc v2, and, in point of fact, marking this package as a conflict makes it impossible to create forwards-compatible packages that work with routing.
