### PR TITLE
[docs] Rename http route types

### DIFF
--- a/doc/book/routing.md
+++ b/doc/book/routing.md
@@ -153,7 +153,7 @@ route.
 
 zend-mvc ships with the following HTTP route types.
 
-### Zend\\Mvc\\Router\\Http\\Hostname
+### Zend\\Router\\Http\\Hostname
 
 The `Hostname` route attempts to match the hostname registered in the request
 against specific criteria. Typically, this will be in one of the following
@@ -198,7 +198,7 @@ $route = Hostname::factory([
 When matched, the above will return two keys in the `RouteMatch`, "subdomain"
 and "type".
 
-### Zend\\Mvc\\Router\\Http\\Literal
+### Zend\\Router\\Http\\Literal
 
 The `Literal` route is for doing exact matching of the URI path. Configuration
 therefore is solely the path you want to match, and the "defaults", or
@@ -217,7 +217,7 @@ $route = Literal::factory([
 The above route would match a path "/foo", and return the key "action" in the
 `RouteMatch`, with the value "foo".
 
-### Zend\\Mvc\\Router\\Http\\Method
+### Zend\\Router\\Http\\Method
 
 The `Method` route is used to match the HTTP method or 'verb' specified in the
 request (See RFC 2616 Sec. 5.1.1). It can optionally be configured to match
@@ -236,7 +236,7 @@ $route = Method::factory([
 The above route would match an http "POST" or "PUT" request and return a
 `RouteMatch` object containing a key "action" with a value of "form-submit".
 
-### Zend\\Mvc\\Router\\Http\\Part
+### Zend\\Router\\Http\\Part
 
 A `Part` route allows crafting a tree of possible routes based on segments of
 the URI path. It actually extends the `TreeRouteStack`.
@@ -353,7 +353,7 @@ You may use any route type as a child route of a `Part` route.
 > set up by default, and the developer does not need to worry about autoloading
 > of standard HTTP routes.
 
-### Zend\\Mvc\\Router\\Http\\Regex
+### Zend\\Router\\Http\\Regex
 
 A `Regex` route utilizes a regular expression to match against the URI path. Any
 valid regular expression is allowed; our recommendation is to use named captures
@@ -385,7 +385,7 @@ items in the `RouteMatch`, an "id", the "controller", the "action", and the
 "format". When assembling a URL from this route, the "id" and "format" values
 would be used to fill the specification.
 
-### Zend\\Mvc\\Router\\Http\\Scheme
+### Zend\\Router\\Http\\Scheme
 
 The `Scheme` route matches the URI scheme only, and must be an exact match. As
 such, this route, like the `Literal` route, simply takes what you want to match
@@ -403,7 +403,7 @@ $route = Scheme::factory([
 The above route would match the "https" scheme, and return the key "https" in
 the `RouteMatch` with a boolean `true` value.
 
-### Zend\\Mvc\\Router\\Http\\Segment
+### Zend\\Router\\Http\\Segment
 
 A `Segment` route allows matching any segment of a URI path. Segments are
 denoted using a colon, followed by alphanumeric characters; if a segment is
@@ -440,7 +440,7 @@ $route = Segment::factory([
 ]);
 ```
 
-### Zend\\Mvc\\Router\\Http\\Query (Deprecated)
+### Zend\\Router\\Http\\Query (Deprecated)
 
 > #### Potential security issue
 >
@@ -507,7 +507,7 @@ will then be appended as a query string.
 The output from our example should then be
 `/page/my-test-page?format=rss&limit=10`
 
-### Zend\\Mvc\\Router\\Http\\Wildcard (Deprecated)
+### Zend\\Router\\Http\\Wildcard (Deprecated)
 
 > #### Potential security issue
 >

--- a/doc/book/routing.md
+++ b/doc/book/routing.md
@@ -70,7 +70,7 @@ interface RouteStackInterface extends RouteInterface
 ```
 
 Routes will be queried in a LIFO order, and hence the reason behind the name
-`RouteStack`. zend-mvc provides two implementations of this interface,
+`RouteStack`. zend-router provides two implementations of this interface,
 `SimpleRouteStack` and `TreeRouteStack`. In each, you register routes either one
 at a time using `addRoute()`, or in bulk using `addRoutes()`.
 
@@ -108,7 +108,7 @@ $router->addRoutes([
 
 Two routers are provided, the `SimpleRouteStack` and `TreeRouteStack`. Each
 works with the above interface, but utilize slightly different options and
-execution paths. By default, the zend-mvc uses the `TreeRouteStack` as the
+execution paths. By default, the zend-router uses the `TreeRouteStack` as the
 router.
 
 ### SimpleRouteStack
@@ -151,7 +151,7 @@ route.
 
 ## HTTP Route Types
 
-zend-mvc ships with the following HTTP route types.
+zend-router ships with the following HTTP route types.
 
 ### Zend\\Router\\Http\\Hostname
 


### PR DESCRIPTION
The HTTP Route types are located in Zend\Router, not Zend\Mvc\Router.
Also some references to the old package name are fixed.
