### PR TITLE
fix prototype for PHP 7.2

### DIFF
--- a/test/Http/TestAsset/DummyRouteWithParam.php
+++ b/test/Http/TestAsset/DummyRouteWithParam.php
@@ -22,7 +22,7 @@ class DummyRouteWithParam extends DummyRoute
      * @param  RequestInterface $request
      * @return RouteMatch
      */
-    public function match(RequestInterface $request)
+    public function match(RequestInterface $request, $pathOffset = null)
     {
         return new RouteMatch(['foo' => 'bar'], -4);
     }


### PR DESCRIPTION
Discovered in Fedora QA with PHP 7.2.0RC4
https://apps.fedoraproject.org/koschei/package/php-zendframework-zend-router?collection=f28

`PHP Fatal error:  Declaration of ZendTest\Router\Http\TestAsset\DummyRouteWithParam::match(Zend\Stdlib\RequestInterface $request) must be compatible with ZendTest\Router\Http\TestAsset\DummyRoute::match(Zend\Stdlib\RequestInterface $request, $pathOffset = NULL) in /builddir/build/BUILD/zend-router-03763610632a9022aff22a0e8f340852e68392a1/test/Http/TestAsset`