### PR TITLE
Ensure wildcard route assembly skips non-scalar values

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ All notable changes to this project will be documented in this file, in reverse 
 
 - Nothing.
 
+### Changed
+
+- Nothing.
+
 ### Deprecated
 
 - Nothing.
@@ -18,7 +22,10 @@ All notable changes to this project will be documented in this file, in reverse 
 
 ### Fixed
 
-- Nothing.
+- [#47](https://github.com/zendframework/zend-router/pull/47) fixes how the `Wildcard` URL assembly works. Previously, it would
+  attempt to `rawurlencode()` all values provided to the method as merged with any default values.
+  It now properly skips any non-scalar values when assembling the URL path. This fixes an issue
+  discovered when providing an array of middleware as a `middleware` default route parameter.
 
 ## 3.0.2 - 2016-05-31
 

--- a/src/Http/Wildcard.php
+++ b/src/Http/Wildcard.php
@@ -168,8 +168,11 @@ class Wildcard implements RouteInterface
 
         if ($mergedParams) {
             foreach ($mergedParams as $key => $value) {
-                $elements[] = rawurlencode($key) . $this->keyValueDelimiter . rawurlencode($value);
+                if (! is_scalar($value)) {
+                    continue;
+                }
 
+                $elements[] = rawurlencode($key) . $this->keyValueDelimiter . rawurlencode($value);
                 $this->assembledParams[] = $key;
             }
 

--- a/test/Http/WildcardTest.php
+++ b/test/Http/WildcardTest.php
@@ -189,4 +189,19 @@ class WildcardTest extends TestCase
 
         $this->assertSame($out, $match->getParam('foo'));
     }
+
+    public function testPathAssemblyShouldSkipAnyNonScalarValues()
+    {
+        $route = new Wildcard('/', '/', [
+            'action' => 'index',
+            'controller' => 'index',
+            'middleware' => [
+                \Some\ConnectMiddleware::class,
+                \Some\Handler::class,
+            ],
+        ]);
+
+        $path = $route->assemble();
+        $this->assertEquals('/action/index/controller/index', $path);
+    }
 }


### PR DESCRIPTION
When routing to middleware, you may provide an array of middleware. In such cases, the wildcard router was attempting to `rawurlencode()` that array, leading to a fatal error.

This patch modifies the logic to skip non-scalar values.

Fixes #46